### PR TITLE
[Feature] Playlist Model/View/Controller

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -33,3 +33,11 @@
   width: 100%;
   opacity: 0.4;
 }
+
+.margin-left-small {
+  margin-left: 4px;
+}
+
+.margin-left-large {
+  margin-left: 32px;
+}

--- a/app/controllers/api/v1/playlist_controller.rb
+++ b/app/controllers/api/v1/playlist_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::PlaylistController < ApplicationController
+  def index
+    playlists = Playlist.where(user: current_user)
+    render json: playlists
+  end
+end

--- a/app/controllers/api/v1/playlist_controller.rb
+++ b/app/controllers/api/v1/playlist_controller.rb
@@ -1,7 +1,13 @@
 class Api::V1::PlaylistController < ApplicationController
+  before_action :set_playlist, only: [:show]
+
   def index
     playlists = Playlist.where(user: current_user)
     render json: playlists
+  end
+
+  def show
+    render json: @playlist
   end
 
   def create
@@ -9,6 +15,10 @@ class Api::V1::PlaylistController < ApplicationController
   end
 
   private
+
+  def set_playlist
+    @playlist = Playlist.find(params[:id])
+  end
 
   def playlist_params
     params.permit(:name)

--- a/app/controllers/api/v1/playlist_controller.rb
+++ b/app/controllers/api/v1/playlist_controller.rb
@@ -3,4 +3,14 @@ class Api::V1::PlaylistController < ApplicationController
     playlists = Playlist.where(user: current_user)
     render json: playlists
   end
+
+  def create
+    playlist = Playlist.create!(playlist_params.merge(user: current_user))
+  end
+
+  private
+
+  def playlist_params
+    params.permit(:name)
+  end
 end

--- a/app/javascript/components/CreatePlaylist.tsx
+++ b/app/javascript/components/CreatePlaylist.tsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import { createPlaylist } from '../services';
+import { Link } from 'react-router-dom';
+
+export default (): JSX.Element => {
+
+    const [playlistName, setPlaylistName] = useState<string>('');
+
+    const handleSubmit = async (): Promise<void> => {
+        if (playlistName.length === 0) {
+            alert('Please enter a playlist name');
+            return;
+        };
+
+        const success = await createPlaylist(playlistName);
+        if (success) {
+            alert('Successfully created playlist');
+            window.open(`/`); 
+        } else {
+            alert('Failed to create playlist!');
+        };
+    };
+
+    return(
+        <div className='margin-left-large mt-4'>
+            <h2>Create Playlist</h2>
+            <div className="d-flex align-items-center mt-2">
+                <label>Playlist:</label>
+                <input type='text' placeholder='My first playlist' className='margin-left-small' onChange={(e) =>  setPlaylistName(e.target.value)}></input>
+            </div>
+            <button onClick={handleSubmit} className='btn btn-lg custom-button mt-4'>Create Playlist</button>
+            <div>
+                <Link to='/' className='btn btn-lg custom-button mt-2'>Navigate Home</Link>
+            </div>
+        </div>
+    );
+};

--- a/app/javascript/components/Playlist.tsx
+++ b/app/javascript/components/Playlist.tsx
@@ -1,0 +1,33 @@
+import React, { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import { getPlaylist } from '../services';
+import { Playlist } from '../types/playlist';
+import { Link } from 'react-router-dom';
+
+export default (): JSX.Element => {
+
+    const { id } = useParams();
+    const [playlist, setPlaylist] = useState<Playlist | null>();
+
+    useEffect(() => {
+        const fetchItem = async (): Promise<void> => {
+            const playlist = await getPlaylist(Number(id));
+            setPlaylist(playlist);
+        };
+
+        fetchItem();
+    }, []);
+
+    if (!playlist) {
+        return <></>;
+    }
+
+    return(
+        <div>
+            <h2 className='text-center'>Playlist: {playlist.name}</h2>
+            <div className='d-flex justify-content-center'>
+                <Link to='/' className='btn btn-lg custom-button mt-2'>Navigate Home</Link>
+            </div>
+        </div>
+    );
+};

--- a/app/javascript/components/Playlists.tsx
+++ b/app/javascript/components/Playlists.tsx
@@ -1,0 +1,48 @@
+import React, {
+    useState,
+    useEffect,
+} from 'react';
+import { Playlist } from '../types/playlist';
+import { getPlaylists } from '../services';
+import { Link } from 'react-router-dom';
+
+export default () => {
+
+    const [playlists, setPlaylists] = useState<Playlist[]>([]);
+
+    useEffect(() => {
+        const fetchPlaylists = async (): Promise<void> => {
+            const playlists = await getPlaylists();
+            setPlaylists(playlists);
+        };
+
+        fetchPlaylists();
+    }, []);
+
+    if (playlists.length === 0) {
+        return <></>;
+    };
+
+    return (
+        <div className="table-responsive">
+            <table className="mx-auto w-75">
+                <tr>
+                    <th className='border w-50'>Playlist</th>
+                    <th className='border w-50'>Video Count</th>
+                </tr>
+                {
+                    playlists.map((playlist: Playlist) => {
+                        return <tr>
+                            <td className='border'>
+                                <Link to={`/playlist/${playlist.id}`}>
+                                    {playlist.name}
+                                </Link>
+                            </td>
+                            <td className='border'>X</td>
+                        </tr>
+                    })
+                }
+            </table>
+        </div>
+    );
+};

--- a/app/javascript/components/Playlists.tsx
+++ b/app/javascript/components/Playlists.tsx
@@ -6,6 +6,20 @@ import { Playlist } from '../types/playlist';
 import { getPlaylists } from '../services';
 import { Link } from 'react-router-dom';
 
+export const CreatePlaylistButtom = (): JSX.Element => {
+    return (
+        <div className="d-flex justify-content-center mt-4">
+            <Link
+                to="/createPlaylist"
+                className="btn btn-lg custom-button"
+                role="button"
+                >
+                Create Playlist
+            </Link>
+        </div>
+    );
+};
+
 export default () => {
 
     const [playlists, setPlaylists] = useState<Playlist[]>([]);
@@ -20,7 +34,7 @@ export default () => {
     }, []);
 
     if (playlists.length === 0) {
-        return <></>;
+        return <CreatePlaylistButtom />;
     };
 
     return (
@@ -43,15 +57,7 @@ export default () => {
                     })
                 }
             </table>
-            <div className="d-flex justify-content-center mt-4">
-                <Link
-                    to="/createPlaylist"
-                    className="btn btn-lg custom-button"
-                    role="button"
-                    >
-                    Create Playlist
-                </Link>
-            </div>
+            <CreatePlaylistButtom />
         </div>
     );
 };

--- a/app/javascript/components/Playlists.tsx
+++ b/app/javascript/components/Playlists.tsx
@@ -43,6 +43,15 @@ export default () => {
                     })
                 }
             </table>
+            <div className="d-flex justify-content-center mt-4">
+                <Link
+                    to="/createPlaylist"
+                    className="btn btn-lg custom-button"
+                    role="button"
+                    >
+                    Create Playlist
+                </Link>
+            </div>
         </div>
     );
 };

--- a/app/javascript/routes/index.jsx
+++ b/app/javascript/routes/index.jsx
@@ -1,11 +1,14 @@
 import React from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
-import Home from "../components/Home";
+import Playlist from "../components/Playlist";
+import Playlists from "../components/Playlists";
 
 export default (
   <Router>
     <Routes>
-      <Route path="/" element={<Home />} />
+      <Route path="/" exact element={<Playlists />} />
+      <Route path="/playlist/:id" element={<Playlist />} />
+      <Route path="/playlists" element={<Playlists />} />
     </Routes>
   </Router>
 );

--- a/app/javascript/routes/index.jsx
+++ b/app/javascript/routes/index.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import Playlist from "../components/Playlist";
 import Playlists from "../components/Playlists";
+import CreatePlaylist from "../components/CreatePlaylist";
 
 export default (
   <Router>
@@ -9,6 +10,7 @@ export default (
       <Route path="/" exact element={<Playlists />} />
       <Route path="/playlist/:id" element={<Playlist />} />
       <Route path="/playlists" element={<Playlists />} />
+      <Route path="/createPlaylist" element={<CreatePlaylist />} />
     </Routes>
   </Router>
 );

--- a/app/javascript/services/index.ts
+++ b/app/javascript/services/index.ts
@@ -33,3 +33,31 @@ export const getPlaylists = async (): Promise<Playlist[]> => {
         return [];
     };
 };
+
+export const createPlaylist = async (name: string): Promise<Boolean> => {
+    const url = `/api/v1/playlist/create`;
+    const body = {
+        name,
+    };
+
+    try {
+        const token = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content');
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: {
+                "X-CSRF-Token": token as string,
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify(body),
+        });
+
+        if (response.ok) {
+            return true;
+        } else {
+            throw response;
+        }
+    } catch(e) {
+        console.warn(e);
+        return false;
+    };
+};

--- a/app/javascript/services/index.ts
+++ b/app/javascript/services/index.ts
@@ -1,0 +1,35 @@
+import { Playlist } from "../types/playlist";
+
+export const getPlaylist = async (id: number): Promise<Playlist | null> => {
+    const url = `/api/v1/playlist/show/${id}`;
+    try {
+        const response = await fetch(url);
+
+        if (response.ok) {
+            const playlist = await response.json();
+            return playlist;
+        } else {
+            throw response;
+        }
+    } catch(e) {
+        console.warn(e);
+        return null;
+    };
+};
+
+export const getPlaylists = async (): Promise<Playlist[]> => {
+    const url = `/api/v1/playlist/index`;
+    try {
+        const response = await fetch(url);
+
+        if (response.ok) {
+            const playlists = await response.json();
+            return playlists;
+        } else {
+            throw response;
+        }
+    } catch(e) {
+        console.warn(e);
+        return [];
+    };
+};

--- a/app/javascript/types/playlist.ts
+++ b/app/javascript/types/playlist.ts
@@ -1,0 +1,7 @@
+export type Playlist = {
+    id: number,
+    name: string,
+    user_id: number,
+    created_at: string,
+    updated_at: string,
+};

--- a/app/models/playlist.rb
+++ b/app/models/playlist.rb
@@ -1,0 +1,5 @@
+class Playlist < ApplicationRecord
+  belongs_to :user
+
+  validates :name, presence: true
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       get 'playlist/index'
+      post 'playlist/create'
     end
   end
   devise_for :users

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       get 'playlist/index'
       post 'playlist/create'
+      get 'playlist/show/:id', to: 'playlist#show'
     end
   end
   devise_for :users

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,9 @@
 Rails.application.routes.draw do
+  namespace :api do
+    namespace :v1 do
+      get 'playlist/index'
+    end
+  end
   devise_for :users
   root 'homepage#index'
   get '/*path' => 'homepage#index'

--- a/db/migrate/20240521214540_create_playlists.rb
+++ b/db/migrate/20240521214540_create_playlists.rb
@@ -1,0 +1,14 @@
+class CreatePlaylists < ActiveRecord::Migration[7.0]
+  def up
+    create_table :playlists do |t|
+      t.string :name, presence: true
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+
+  def down
+    drop_table :playlists
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -22,15 +22,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_21_214540) do
     t.index ["user_id"], name: "index_playlists_on_user_id"
   end
 
-  create_table "recipes", force: :cascade do |t|
-    t.string "name", null: false
-    t.text "ingredients", null: false
-    t.text "instruction", null: false
-    t.string "image", default: "https://raw.githubusercontent.com/do-community/react_rails_recipe/master/app/assets/images/Sammy_Meal.jpg"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_02_192452) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_21_214540) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "playlists", force: :cascade do |t|
+    t.string "name"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_playlists_on_user_id"
+  end
 
   create_table "recipes", force: :cascade do |t|
     t.string "name", null: false
@@ -35,4 +43,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_02_192452) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "playlists", "users"
 end

--- a/spec/controllers/api/v1/playlist_controller_spec.rb
+++ b/spec/controllers/api/v1/playlist_controller_spec.rb
@@ -30,4 +30,14 @@ RSpec.describe Api::V1::PlaylistController, type: :controller do
       expect { post :create, params: params }.to change{ Playlist.count }.by(1)
     end
   end
+
+  describe "GET #show" do
+    let!(:user) { create(:user) }
+    let!(:playlist) { create(:playlist, user: user) }
+
+    it "returns http success" do
+      get :show, params: { id: playlist.id }
+      expect(JSON.parse(response.body)).to eq(playlist.as_json)
+    end
+  end
 end

--- a/spec/controllers/api/v1/playlist_controller_spec.rb
+++ b/spec/controllers/api/v1/playlist_controller_spec.rb
@@ -20,4 +20,14 @@ RSpec.describe Api::V1::PlaylistController, type: :controller do
       expect(JSON.parse(response.body)).to eq([playlist_1.as_json])
     end
   end
+
+  describe "POST #create" do
+    let!(:user) { create(:user) }
+    before { allow(controller).to receive(:current_user) { user } }
+
+    it "returns http success" do
+      params = {name: 'My new playlist'}
+      expect { post :create, params: params }.to change{ Playlist.count }.by(1)
+    end
+  end
 end

--- a/spec/controllers/api/v1/playlist_controller_spec.rb
+++ b/spec/controllers/api/v1/playlist_controller_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::PlaylistController, type: :controller do
+
+  describe "GET #index" do
+    let!(:user_1) { create(:user) }
+    let!(:user_2) { create(:user) }
+    let!(:playlist_1) { create(:playlist, user: user_1) }
+    let!(:playlist_2) { create(:playlist, user: user_2) }
+
+    before { allow(controller).to receive(:current_user) { user_1 } }
+
+    it "returns http success" do
+      get :index
+      expect(response).to have_http_status(:success)
+    end
+
+    it "returns an array of playlists" do
+      get :index
+      expect(JSON.parse(response.body)).to eq([playlist_1.as_json])
+    end
+  end
+end

--- a/spec/factories/playlists.rb
+++ b/spec/factories/playlists.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :playlist do
+    name "Playlist 1"
+    user nil
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,8 @@
 FactoryGirl.define do
   factory :user do
-    
+    sequence :email do |n|
+      "test123-#{n}@hotmail.com"
+    end
+    password 'test123'
   end
 end

--- a/spec/models/playlist_spec.rb
+++ b/spec/models/playlist_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe Playlist, type: :model do
+  describe '#user' do
+    it 'is valid with a user' do
+      user = create(:user)
+      playlist = create(:playlist, user: user)
+      expect(playlist.valid?).to eq(true)
+    end
+
+    it 'is not valid without a user' do
+      expect { create(:playlist) }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
+
+  describe '#name' do
+    it 'is not valid without a name' do
+      user = create(:user)
+      playlist = create(:playlist, user: user)
+      playlist.update(name: nil)
+      expect(playlist.valid?).to eq(false)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,6 +63,7 @@ RSpec.configure do |config|
   end
 
   config.include FactoryGirl::Syntax::Methods
+  config.include Devise::Test::ControllerHelpers, type: :controller
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and


### PR DESCRIPTION
- modify user factory to define necessary properties
- run command ```rails generate model Playlist name:string user:references```
- add spec file to test new Playlist model ensuring User and name is set
- adjust migration to support dropping table and requiring properties to be set
- runs ```rails generate controller api/v1/Playlist index --skip-template-engine --no-helper``` to create the index route to display all playlists
- modifies controller and adds associated spec tests
- adds devise to rails_helper to allow access to current_user when running rspec
- limits only seeing the users playlists -- DESIGN DECISION
- adds a new post route for the Playlist controller, and adds associated testing
- adds a private method to only permit certain parameters
- adds new Playlist and Playlists component displaying the contents of one playlist or multiple
- adds routes to these new components
- adds a services folder with two service get playlist which links to our show action and get playlists which links to our index action
- adds Playlist type
- adds new create playlist component that allows a user to input a name
- adds a route to reach this new component
- adds new service to call the api to create the playlist
- adds a button on the Playlists list to navigate to create an Playlist
- slight improvement, where if the database is wiped the create item button still shows, allowing the user to flow through the process