### PR TITLE
[Video] Video Model + Controller + Associated Logic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,5 +80,6 @@ end
 
 gem "devise" 
 gem "httparty"
+gem "active_model_serializers", require: true
 
 

--- a/Gemfile
+++ b/Gemfile
@@ -79,5 +79,6 @@ group :development do
 end
 
 gem "devise" 
+gem "httparty"
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,7 @@ GEM
     addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
     bcrypt (3.1.19)
+    bigdecimal (3.1.3)
     bindex (0.8.1)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
@@ -88,6 +89,7 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.3.3)
       railties (>= 6.0.0)
+    csv (3.2.6)
     database_cleaner (2.0.2)
       database_cleaner-active_record (>= 2, < 3)
     database_cleaner-active_record (2.1.0)
@@ -113,6 +115,10 @@ GEM
       railties (>= 3.0.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    httparty (0.22.0)
+      csv
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     io-console (0.6.0)
@@ -138,6 +144,8 @@ GEM
     mini_mime (1.1.5)
     minitest (5.20.0)
     msgpack (1.7.2)
+    multi_xml (0.7.1)
+      bigdecimal (~> 3.1)
     net-imap (0.3.7)
       date
       net-protocol
@@ -268,6 +276,7 @@ DEPENDENCIES
   debug
   devise
   factory_girl_rails
+  httparty
   jbuilder
   jsbundling-rails
   pg (~> 1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_model_serializers (0.10.14)
+      actionpack (>= 4.1)
+      activemodel (>= 4.1)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (7.0.8)
       activesupport (= 7.0.8)
       globalid (>= 0.3.6)
@@ -84,6 +89,8 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    case_transform (0.2)
+      activesupport
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
@@ -130,6 +137,7 @@ GEM
       activesupport (>= 5.0.0)
     jsbundling-rails (1.2.1)
       railties (>= 6.0.0)
+    jsonapi-renderer (0.2.2)
     loofah (2.21.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -268,6 +276,7 @@ PLATFORMS
   x86_64-darwin-22
 
 DEPENDENCIES
+  active_model_serializers
   bootsnap
   byebug
   capybara

--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -41,3 +41,15 @@
 .margin-left-large {
   margin-left: 32px;
 }
+
+.caret-container {
+  display: flex;
+  height: 300px;
+  width: 500px;
+  justify-content: center;
+  align-items: center;
+}
+
+.caret {
+  border: 1px solid black;
+}

--- a/app/controllers/api/v1/playlist_controller.rb
+++ b/app/controllers/api/v1/playlist_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::PlaylistController < ApplicationController
 
   def index
     playlists = Playlist.where(user: current_user)
-    render json: playlists
+    render json: playlists, each_serializer: PlaylistSerializer
   end
 
   def show

--- a/app/controllers/api/v1/playlist_controller.rb
+++ b/app/controllers/api/v1/playlist_controller.rb
@@ -12,6 +12,7 @@ class Api::V1::PlaylistController < ApplicationController
 
   def create
     playlist = Playlist.create!(playlist_params.merge(user: current_user))
+    render json: playlist
   end
 
   private
@@ -21,6 +22,6 @@ class Api::V1::PlaylistController < ApplicationController
   end
 
   def playlist_params
-    params.permit(:name)
+    params.permit(:name, videos_attributes: [:title, :description, :thumbnail_url, :views])
   end
 end

--- a/app/controllers/api/v1/video_controller.rb
+++ b/app/controllers/api/v1/video_controller.rb
@@ -1,0 +1,8 @@
+class Api::V1::VideoController < ApplicationController
+  def index
+    page = params[:page] || '1'
+    
+    response = HTTParty.get('https://mock-youtube-api-f3d0c17f0e38.herokuapp.com/api/videos?page=' + page)
+    render json: response
+  end
+end

--- a/app/javascript/components/CreatePlaylist.tsx
+++ b/app/javascript/components/CreatePlaylist.tsx
@@ -1,10 +1,19 @@
-import React, { useState } from 'react';
-import { createPlaylist } from '../services';
+import React, { useState, useEffect } from 'react';
+import { createPlaylist, getVideos } from '../services';
 import { Link } from 'react-router-dom';
 
 export default (): JSX.Element => {
 
     const [playlistName, setPlaylistName] = useState<string>('');
+    const [videos, setVideos] = useState<any[]>([]);
+
+    useEffect(() => {
+        const fetchVideos = async (): Promise<void> => {
+            const videos = await getVideos(1);
+            setVideos(videos);
+        };
+        fetchVideos();
+    }, []);
 
     const handleSubmit = async (): Promise<void> => {
         if (playlistName.length === 0) {
@@ -24,10 +33,17 @@ export default (): JSX.Element => {
     return(
         <div className='margin-left-large mt-4'>
             <h2>Create Playlist</h2>
-            <div className="d-flex align-items-center mt-2">
+            <div className="d-flex align-items-center mt-4">
                 <label>Playlist:</label>
                 <input type='text' placeholder='My first playlist' className='margin-left-small' onChange={(e) =>  setPlaylistName(e.target.value)}></input>
             </div>
+            {
+                videos && (
+                    <div className="d-flex align-items-center mt-4">
+                        <img src="https://i.ytimg.com/vi/wb6mcEdcjXA/default.jpg" alt="video thumbnail" width="150" height="150"/>
+                    </div>
+                )
+            }
             <button onClick={handleSubmit} className='btn btn-lg custom-button mt-4'>Create Playlist</button>
             <div>
                 <Link to='/' className='btn btn-lg custom-button mt-2'>Navigate Home</Link>

--- a/app/javascript/components/CreatePlaylist.tsx
+++ b/app/javascript/components/CreatePlaylist.tsx
@@ -1,19 +1,30 @@
 import React, { useState, useEffect } from 'react';
 import { createPlaylist, getVideos } from '../services';
+import { VideoAPI, Video, emptyVideoResponse } from '../types/video';
 import { Link } from 'react-router-dom';
 
 export default (): JSX.Element => {
 
     const [playlistName, setPlaylistName] = useState<string>('');
-    const [videos, setVideos] = useState<any[]>([]);
+    const [videoAPI, setVideoAPI] = useState<VideoAPI>(emptyVideoResponse);
+    const [selectedVideos, setSelectedVideos] = useState<Video[]>([]);
+    const [currIndex, setCurrIndex] = useState<number>(0);
+    const [page, setPage] = useState<number>(1);
+
+    const numberToDisplay = 5; // design decision to only display 5 videos at a time
 
     useEffect(() => {
         const fetchVideos = async (): Promise<void> => {
-            const videos = await getVideos(1);
-            setVideos(videos);
+            const videoAPIResp = await getVideos(page);
+            console.log(videoAPIResp, "HERE", page);
+            setPage(page);
+            setVideoAPI(videoAPIResp);
+            const filteredVideos = videoAPIResp["videos"].slice(currIndex * 5, currIndex * 5 + 5);
+            setSelectedVideos(filteredVideos);
         };
+
         fetchVideos();
-    }, []);
+    }, [page]);
 
     const handleSubmit = async (): Promise<void> => {
         if (playlistName.length === 0) {
@@ -30,6 +41,32 @@ export default (): JSX.Element => {
         };
     };
 
+    const decrementIndex = (): void => {
+        if (currIndex === 0) {
+            setCurrIndex(3);
+            setPage(page - 1);
+            console.log("Decrementing page");
+        } else {
+            const firstVideoIndex = (currIndex - 1) * 5;
+            const filteredVideos = videoAPI["videos"].slice(firstVideoIndex, firstVideoIndex + 5);
+            setSelectedVideos(filteredVideos);
+            setCurrIndex(currIndex - 1);
+        };
+    };
+
+    const incrementIndex = (): void => {
+        if (currIndex === 3) {
+            console.log("Incrementing page");
+            setCurrIndex(0);
+            setPage(page + 1);
+        } else {
+            const firstVideoIndex = (currIndex + 1) * 5;
+            const filteredVideos = videoAPI["videos"].slice(firstVideoIndex, firstVideoIndex + 5);
+            setSelectedVideos(filteredVideos);
+            setCurrIndex(currIndex + 1);
+        }
+    };
+
     return(
         <div className='margin-left-large mt-4'>
             <h2>Create Playlist</h2>
@@ -37,10 +74,24 @@ export default (): JSX.Element => {
                 <label>Playlist:</label>
                 <input type='text' placeholder='My first playlist' className='margin-left-small' onChange={(e) =>  setPlaylistName(e.target.value)}></input>
             </div>
+            <h3 className="mt-4">Optional Videos (click to add to playlist):</h3>
             {
-                videos && (
-                    <div className="d-flex align-items-center mt-4">
-                        <img src="https://i.ytimg.com/vi/wb6mcEdcjXA/default.jpg" alt="video thumbnail" width="150" height="150"/>
+                videoAPI && (
+                    <div className="d-flex align-items-center">
+                        {
+                            (currIndex > 0 || page !== 1) && <i className="bi bi-caret-left" onClick={decrementIndex}></i>
+                        }
+                        {
+                            selectedVideos && selectedVideos.map((video) => {
+                                return <div key={video.id} className="mt-4">
+                                    <label>{video.id}</label>
+                                    <img src={video.thumbnail_url} alt="video thumbnail" width="150" height="150" />
+                                </div>
+                            })
+                        }
+                        {
+                            (page - 1) * 20 + currIndex * 5 < videoAPI.meta.total && <i className="bi bi-caret-right" onClick={incrementIndex}></i>
+                        }
                     </div>
                 )
             }

--- a/app/javascript/components/CreatePlaylist.tsx
+++ b/app/javascript/components/CreatePlaylist.tsx
@@ -90,7 +90,7 @@ export default (): JSX.Element => {
                             })
                         }
                         {
-                            (page - 1) * 20 + currIndex * 5 < videoAPI.meta.total && <i className="bi bi-caret-right" onClick={incrementIndex}></i>
+                            ((page * 20) < videoAPI.meta.total || videoAPI["videos"][videoAPI["videos"].length - 1] !== selectedVideos[selectedVideos.length - 1]) && <i className="bi bi-caret-right" onClick={incrementIndex}></i>
                         }
                     </div>
                 )

--- a/app/javascript/components/CreatePlaylist.tsx
+++ b/app/javascript/components/CreatePlaylist.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { createPlaylist, getVideos } from '../services';
 import { VideoAPI, Video, emptyVideoResponse } from '../types/video';
 import { Link } from 'react-router-dom';
+import PlaylistTable from './PlaylistTable';
 
 export default (): JSX.Element => {
 
@@ -96,30 +97,7 @@ export default (): JSX.Element => {
                             (currIndex > 0 || page !== 1) &&
                                 <div className="caret-container"><i className="bi bi-caret-left caret" onClick={decrementIndex}></i></div>
                         }
-                        <table className="mx-auto">
-                            <thead>
-                                <tr>
-                                    <th>Id</th>
-                                    <th>Thumbnail</th>
-                                    <th>Title</th>
-                                    <th className='w-50'>Description</th>
-                                    <th>View Count</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {
-                                    displayedVideos && displayedVideos.map((video) => {
-                                        return <tr key={video.id} className="mt-4" onClick={() => addVideoToPlaylist(video)}>
-                                            <td>{video.id}</td>
-                                            <td><img src={video.thumbnail_url} alt="video thumbnail" width="150" height="150" /> </td>
-                                            <td>{video.title}</td>
-                                            <td>{video.description?.substring(0, 100)}{video.description?.length >= 100 ? '...' : ''}</td>
-                                            <td>{video.views}</td>
-                                        </tr>
-                                    })
-                                }
-                            </tbody>
-                        </table>
+                        <PlaylistTable videos={displayedVideos} addVideoToPlaylist={addVideoToPlaylist} />
                         {
                             ((page * 20) < videoAPI.meta.total || videoAPI["videos"][videoAPI["videos"].length - 1] !== displayedVideos[displayedVideos.length - 1]) &&
                                 <div className="caret-container"><i className="bi bi-caret-right caret" onClick={incrementIndex}></i></div>

--- a/app/javascript/components/CreatePlaylist.tsx
+++ b/app/javascript/components/CreatePlaylist.tsx
@@ -33,7 +33,7 @@ export default (): JSX.Element => {
             return;
         };
 
-        const success = await createPlaylist(playlistName);
+        const success = await createPlaylist(playlistName, selectedVideos);
         if (success) {
             alert('Successfully created playlist');
             window.open(`/`); 

--- a/app/javascript/components/CreatePlaylist.tsx
+++ b/app/javascript/components/CreatePlaylist.tsx
@@ -12,6 +12,8 @@ export default (): JSX.Element => {
     const [currIndex, setCurrIndex] = useState<number>(0);
     const [page, setPage] = useState<number>(1);
     const [selectedVideos, setSelectedVideos] = useState<Video[]>([]);
+    const [searchedVideos, setSearchedVideos] = useState<Video[]>([]);
+    const [searchTerm, setSearchTerm] = useState<string>('');
 
     const numberToDisplay = 5; // design decision to only display 5 videos at a time
 
@@ -82,6 +84,12 @@ export default (): JSX.Element => {
         alert("Removed video from playlist");
     };
 
+    const searchByTitle = (title: string) => {
+        setSearchTerm(title);
+        const filteredVideos = videoAPI["videos"].filter((video) => video.title.toLowerCase().includes(title.toLowerCase()));
+        setSearchedVideos(filteredVideos.slice(0, 5));
+    };
+
     return(
         <div className='margin-left-large mt-4 mb-4'>
             <h2>Create Playlist</h2>
@@ -90,8 +98,9 @@ export default (): JSX.Element => {
                 <input type='text' placeholder='My first playlist' className='margin-left-small' onChange={(e) =>  setPlaylistName(e.target.value)}></input>
             </div>
             <h3 className="mt-4">Optional Videos (click to add to playlist):</h3>
+            <input type='text' placeholder='Search for videos' onChange={(e) => searchByTitle(e.target.value)}></input>
             {
-                videoAPI && (
+                videoAPI && searchTerm === '' && (
                     <div className="d-flex align-items-center border">
                         {
                             (currIndex > 0 || page !== 1) &&
@@ -102,6 +111,13 @@ export default (): JSX.Element => {
                             ((page * 20) < videoAPI.meta.total || videoAPI["videos"][videoAPI["videos"].length - 1] !== displayedVideos[displayedVideos.length - 1]) &&
                                 <div className="caret-container"><i className="bi bi-caret-right caret" onClick={incrementIndex}></i></div>
                         }
+                    </div>
+                )
+            }
+            {
+                searchTerm !== '' && (
+                    <div className="d-flex align-items-center border">
+                        <PlaylistTable videos={searchedVideos} addVideoToPlaylist={addVideoToPlaylist} />
                     </div>
                 )
             }

--- a/app/javascript/components/Playlist.tsx
+++ b/app/javascript/components/Playlist.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { getPlaylist } from '../services';
 import { Playlist } from '../types/playlist';
+import { Video } from '../types/video';
 import { Link } from 'react-router-dom';
 
 export default (): JSX.Element => {
@@ -25,6 +26,30 @@ export default (): JSX.Element => {
     return(
         <div>
             <h2 className='text-center'>Playlist: {playlist.name}</h2>
+            <table className="mx-auto">
+                <thead>
+                    <tr>
+                        <th>Id</th>
+                        <th>Thumbnail</th>
+                        <th>Title</th>
+                        <th className='w-50'>Description</th>
+                        <th>View Count</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {
+                        playlist.videos?.map((video: Partial<Video>) => {
+                            return <tr key={video.id} className="mt-4">
+                                <td>{video.id}</td>
+                                <td><img src={video.thumbnail_url} alt="video thumbnail" width="150" height="150" /> </td>
+                                <td>{video.title}</td>
+                                <td>{video.description?.substring(0, 100)}{video.description && video.description?.length >= 100 ? '...' : ''}</td>
+                                <td>{video.views}</td>
+                            </tr>
+                        })
+                    }
+                </tbody>
+            </table>
             <div className='d-flex justify-content-center'>
                 <Link to='/' className='btn btn-lg custom-button mt-2'>Navigate Home</Link>
             </div>

--- a/app/javascript/components/Playlist.tsx
+++ b/app/javascript/components/Playlist.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom';
 import { getPlaylist } from '../services';
 import { Playlist } from '../types/playlist';
 import { Video } from '../types/video';
+import PlaylistTable from './PlaylistTable';
 import { Link } from 'react-router-dom';
 
 export default (): JSX.Element => {
@@ -26,30 +27,7 @@ export default (): JSX.Element => {
     return(
         <div>
             <h2 className='text-center'>Playlist: {playlist.name}</h2>
-            <table className="mx-auto">
-                <thead>
-                    <tr>
-                        <th>Id</th>
-                        <th>Thumbnail</th>
-                        <th>Title</th>
-                        <th className='w-50'>Description</th>
-                        <th>View Count</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {
-                        playlist.videos?.map((video: Partial<Video>) => {
-                            return <tr key={video.id} className="mt-4">
-                                <td>{video.id}</td>
-                                <td><img src={video.thumbnail_url} alt="video thumbnail" width="150" height="150" /> </td>
-                                <td>{video.title}</td>
-                                <td>{video.description?.substring(0, 100)}{video.description && video.description?.length >= 100 ? '...' : ''}</td>
-                                <td>{video.views}</td>
-                            </tr>
-                        })
-                    }
-                </tbody>
-            </table>
+            <PlaylistTable videos={playlist.videos as Partial<Video>[]} addVideoToPlaylist={() => null} />
             <div className='d-flex justify-content-center'>
                 <Link to='/' className='btn btn-lg custom-button mt-2'>Navigate Home</Link>
             </div>

--- a/app/javascript/components/PlaylistTable.tsx
+++ b/app/javascript/components/PlaylistTable.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Video } from '../types/video';
+
+type PlaylistTableProps = {
+    videos: Partial<Video>[];
+    addVideoToPlaylist: (video: Video) => void;
+};
+export default ({ videos, addVideoToPlaylist }: PlaylistTableProps): JSX.Element => {
+    return (
+        <table className="mx-auto">
+            <thead>
+                <tr>
+                    <th>Id</th>
+                    <th>Thumbnail</th>
+                    <th>Title</th>
+                    <th className='w-50'>Description</th>
+                    <th>View Count</th>
+                </tr>
+            </thead>
+            <tbody>
+                {
+                    videos.map((video: Partial<Video>) => {
+                        return <tr key={video.id} className="mt-4" onClick={() => addVideoToPlaylist?.(video as Video)}>
+                            <td>{video.id}</td>
+                            <td><img src={video.thumbnail_url} alt="video thumbnail" width="150" height="150" /> </td>
+                            <td>{video.title}</td>
+                            <td>{video.description?.substring(0, 100)}{video.description && video.description?.length >= 100 ? '...' : ''}</td>
+                            <td>{video.views}</td>
+                        </tr>
+                    })
+                }
+            </tbody>
+        </table>
+    )
+}

--- a/app/javascript/components/Playlists.tsx
+++ b/app/javascript/components/Playlists.tsx
@@ -52,7 +52,7 @@ export default () => {
                                     {playlist.name}
                                 </Link>
                             </td>
-                            <td className='border'>X</td>
+                            <td className='border'>{playlist.video_count}</td>
                         </tr>
                     })
                 }

--- a/app/javascript/services/index.ts
+++ b/app/javascript/services/index.ts
@@ -1,4 +1,5 @@
 import { Playlist } from "../types/playlist";
+import { VideoAPI, emptyVideoResponse } from "../types/video";
 
 export const getPlaylist = async (id: number): Promise<Playlist | null> => {
     const url = `/api/v1/playlist/show/${id}`;
@@ -62,8 +63,9 @@ export const createPlaylist = async (name: string): Promise<Boolean> => {
     };
 };
 
-export const getVideos = async (page: number): Promise<any> => {
+export const getVideos = async (page: number): Promise<VideoAPI> => {
     const url = `/api/v1/video/index/${page}`;
+    console.log(url, "URL");
     try {
         const response = await fetch(url);
 
@@ -75,6 +77,6 @@ export const getVideos = async (page: number): Promise<any> => {
         }
     } catch(e) {
         console.warn(e);
-        return [];
+        return emptyVideoResponse;
     };
 };

--- a/app/javascript/services/index.ts
+++ b/app/javascript/services/index.ts
@@ -1,5 +1,5 @@
 import { Playlist } from "../types/playlist";
-import { VideoAPI, emptyVideoResponse } from "../types/video";
+import { VideoAPI, Video, emptyVideoResponse } from "../types/video";
 
 export const getPlaylist = async (id: number): Promise<Playlist | null> => {
     const url = `/api/v1/playlist/show/${id}`;
@@ -35,10 +35,11 @@ export const getPlaylists = async (): Promise<Playlist[]> => {
     };
 };
 
-export const createPlaylist = async (name: string): Promise<Boolean> => {
+export const createPlaylist = async (name: string, videos: Video[]): Promise<Boolean> => {
     const url = `/api/v1/playlist/create`;
     const body = {
         name,
+        videos_attributes: videos,
     };
 
     try {

--- a/app/javascript/services/index.ts
+++ b/app/javascript/services/index.ts
@@ -61,3 +61,20 @@ export const createPlaylist = async (name: string): Promise<Boolean> => {
         return false;
     };
 };
+
+export const getVideos = async (page: number): Promise<any> => {
+    const url = `/api/v1/video/index/${page}`;
+    try {
+        const response = await fetch(url);
+
+        if (response.ok) {
+            const videos = await response.json();
+            return videos;
+        } else {
+            throw response;
+        }
+    } catch(e) {
+        console.warn(e);
+        return [];
+    };
+};

--- a/app/javascript/types/playlist.ts
+++ b/app/javascript/types/playlist.ts
@@ -1,3 +1,5 @@
+import { Video } from './video';
+
 export type Playlist = {
     id: number,
     name: string,
@@ -5,4 +7,5 @@ export type Playlist = {
     created_at?: string,
     updated_at?: string,
     video_count?: number,
+    videos?: Partial<Video>[],
 };

--- a/app/javascript/types/playlist.ts
+++ b/app/javascript/types/playlist.ts
@@ -1,7 +1,8 @@
 export type Playlist = {
     id: number,
     name: string,
-    user_id: number,
-    created_at: string,
-    updated_at: string,
+    user_id?: number,
+    created_at?: string,
+    updated_at?: string,
+    video_count?: number,
 };

--- a/app/javascript/types/video.ts
+++ b/app/javascript/types/video.ts
@@ -1,0 +1,28 @@
+export type Video = {
+    id: number;
+    title: string;
+    video_id: string;
+    views: number;
+    likes: number;
+    comments: number;
+    description: string;
+    thumbnail_url: string;
+    created_at: string;
+    updated_at: string;
+};
+
+export type VideoAPI = {
+    videos: Video[];
+    meta: {
+        page: number;
+        total: number;
+    };
+};
+
+export const emptyVideoResponse: VideoAPI = {
+    videos: [],
+    meta: {
+        page: 0,
+        total: 0,
+    },
+};

--- a/app/models/playlist.rb
+++ b/app/models/playlist.rb
@@ -3,4 +3,5 @@ class Playlist < ApplicationRecord
   has_many :videos, dependent: :destroy
 
   validates :name, presence: true
+  accepts_nested_attributes_for :videos
 end

--- a/app/models/playlist.rb
+++ b/app/models/playlist.rb
@@ -1,5 +1,6 @@
 class Playlist < ApplicationRecord
   belongs_to :user
+  has_many :videos, dependent: :destroy
 
   validates :name, presence: true
 end

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -2,4 +2,6 @@ class Video < ApplicationRecord
     validates :thumbnail_url, presence: true
     validates :title, presence: true
     validates :views, presence: true
+
+    belongs_to :playlist
 end

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -1,0 +1,5 @@
+class Video < ApplicationRecord
+    validates :thumbnail_url, presence: true
+    validates :title, presence: true
+    validates :views, presence: true
+end

--- a/app/serializers/playlist_serializer.rb
+++ b/app/serializers/playlist_serializer.rb
@@ -1,0 +1,7 @@
+class PlaylistSerializer < ActiveModel::Serializer
+    attributes :id, :name, :video_count
+
+    def video_count
+        object.videos&.count || 0
+    end
+end

--- a/app/serializers/playlist_serializer.rb
+++ b/app/serializers/playlist_serializer.rb
@@ -1,5 +1,5 @@
 class PlaylistSerializer < ActiveModel::Serializer
-    attributes :id, :name, :video_count
+    attributes :id, :name, :video_count, :videos
 
     def video_count
         object.videos&.count || 0

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
+      get 'video/index/:page', to: 'video#index'
+
       get 'playlist/index'
       post 'playlist/create'
       get 'playlist/show/:id', to: 'playlist#show'

--- a/db/migrate/20240522011412_create_videos.rb
+++ b/db/migrate/20240522011412_create_videos.rb
@@ -1,0 +1,16 @@
+class CreateVideos < ActiveRecord::Migration[7.0]
+  def up
+    create_table :videos do |t|
+      t.string :thumbnail_url, presence: true
+      t.string :title, presence: true
+      t.string :description
+      t.integer :views, presence: true
+
+      t.timestamps
+    end
+  end
+
+  def down
+    drop_table :videos
+  end
+end

--- a/db/migrate/20240522051922_add_playlist_to_video.rb
+++ b/db/migrate/20240522051922_add_playlist_to_video.rb
@@ -1,0 +1,5 @@
+class AddPlaylistToVideo < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :videos, :playlist, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_22_011412) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_22_051922) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -41,7 +41,10 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_22_011412) do
     t.integer "views"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "playlist_id", null: false
+    t.index ["playlist_id"], name: "index_videos_on_playlist_id"
   end
 
   add_foreign_key "playlists", "users"
+  add_foreign_key "videos", "playlists"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_21_214540) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_22_011412) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -32,6 +32,15 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_21_214540) do
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  end
+
+  create_table "videos", force: :cascade do |t|
+    t.string "thumbnail_url"
+    t.string "title"
+    t.string "description"
+    t.integer "views"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   add_foreign_key "playlists", "users"

--- a/spec/controllers/api/v1/playlist_controller_spec.rb
+++ b/spec/controllers/api/v1/playlist_controller_spec.rb
@@ -26,8 +26,9 @@ RSpec.describe Api::V1::PlaylistController, type: :controller do
     before { allow(controller).to receive(:current_user) { user } }
 
     it "returns http success" do
-      params = {name: 'My new playlist'}
+      params = {name: 'My new playlist', videos_attributes: [{title: 'Fake video', description: 'Fake video description', thumbnail_url: 'test.com', views: 10}] }
       expect { post :create, params: params }.to change{ Playlist.count }.by(1)
+      expect { post :create, params: params }.to change{ Video.count }.by(1)
     end
   end
 

--- a/spec/controllers/api/v1/video_controller_spec.rb
+++ b/spec/controllers/api/v1/video_controller_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::VideoController, type: :controller do
+
+  describe "GET #index" do
+
+    it "returns http success" do
+      get :index, params: { page: 1 }
+      expect(response).to have_http_status(:success)
+    end
+
+    it "returns an array of video information" do
+      get :index, params: { page: 1 }
+      expect(JSON.parse(response.body)["videos"][0]["id"]).to eq(1)
+    end
+  end
+end

--- a/spec/factories/videos.rb
+++ b/spec/factories/videos.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :video do
+    thumbnail_url "https://www.youtube.com/watch?v=1234"
+    title "Video Title"
+    description "A Brand New Video!"
+    views 1
+  end
+end

--- a/spec/models/playlist_spec.rb
+++ b/spec/models/playlist_spec.rb
@@ -13,6 +13,15 @@ RSpec.describe Playlist, type: :model do
     end
   end
 
+  describe '#videos' do
+    it 'has videos' do
+      user = create(:user)
+      playlist = create(:playlist, user: user)
+      video = create(:video, playlist: playlist)
+      expect(playlist.videos).to eq([video])
+    end
+  end
+
   describe '#name' do
     it 'is not valid without a name' do
       user = create(:user)

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe Video, type: :model do
+  describe '#description' do
+    it 'is valid even without a description' do
+      video = create(:video)
+      video.update(description: nil)
+      expect(video.valid?).to eq(true)
+    end
+  end
+
+  describe '#title' do
+    it 'is not valid without a title' do
+      video = create(:video)
+      video.update(title: nil)
+      expect(video.valid?).to eq(false)
+    end
+  end
+  
+  describe '#thumbnail_url' do
+    it 'is not valid without a thumbnail_url' do
+      video = create(:video)
+      video.update(thumbnail_url: nil)
+      expect(video.valid?).to eq(false)
+    end
+  end
+
+  describe '#views' do
+    it 'is not valid without views' do
+      video = create(:video)
+      video.update(views: nil)
+      expect(video.valid?).to eq(false)
+    end
+  end
+end

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -1,9 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe Video, type: :model do
+  let(:user) { create(:user) }
+  let(:playlist) { create(:playlist, user: user) }
+
   describe '#description' do
     it 'is valid even without a description' do
-      video = create(:video)
+      video = create(:video, playlist: playlist)
       video.update(description: nil)
       expect(video.valid?).to eq(true)
     end
@@ -11,7 +14,7 @@ RSpec.describe Video, type: :model do
 
   describe '#title' do
     it 'is not valid without a title' do
-      video = create(:video)
+      video = create(:video, playlist: playlist)
       video.update(title: nil)
       expect(video.valid?).to eq(false)
     end
@@ -19,7 +22,7 @@ RSpec.describe Video, type: :model do
   
   describe '#thumbnail_url' do
     it 'is not valid without a thumbnail_url' do
-      video = create(:video)
+      video = create(:video, playlist: playlist)
       video.update(thumbnail_url: nil)
       expect(video.valid?).to eq(false)
     end
@@ -27,8 +30,16 @@ RSpec.describe Video, type: :model do
 
   describe '#views' do
     it 'is not valid without views' do
-      video = create(:video)
+      video = create(:video, playlist: playlist)
       video.update(views: nil)
+      expect(video.valid?).to eq(false)
+    end
+  end
+
+  describe '#playlist' do
+    it 'is not valid without a playlist' do
+      video = create(:video, playlist: playlist)
+      video.update(playlist: nil)
       expect(video.valid?).to eq(false)
     end
   end


### PR DESCRIPTION
- generate the Video model with ```rails generate model Video thumbnail_url:string title:string description:string views:integer```
- adds associated rspec tests, requires specific properties on the model and modifies the factory for readability
- adds gem httparty
- adds new index video route with a pages parameter
- adds associated tests to ensure the API is properly pulling video data
- adds a service call to fetch the videos and displays them on the CreatePlaylist component
- adds VideoAPI type
- adds pagination to display 5 elements at a time; and on a right click on after display 20 elements grab another 20; on a left click after the 20th element re-collect elements
- lengthly logic to hide last carat forward
- format the videos into a nicer table
- displays selected videos
- adds the ability to select and remove a video from a playlist
- creates a migration with the command ```rails g migration AddVideoToPlaylist playlist:references``` to add our references between playlist and video
- updates the models to create relationships
- updates the specs to add these relationships
- adds accepts_nested_attributes_for allowing videos to be passed to the playlist and create them simultaneously
- updates frontend to pass appropriate parameters
- add active_model_serializers gem, and to create a playlist_serializer to grab properties like video_count
- display the video_count on the frontend
- adds display of the videos selected on the playlist view
- updates playlist type to support having videos
- refactor to reuse the same table on the Playlist and CreatePlaylist component
- adds the ability to search and makes it case insensitive, additionally holds the current index when the term is removed
